### PR TITLE
Update regex to accept @ style pdg attribs

### DIFF
--- a/houdini/scripts/python/ftrimify.py
+++ b/houdini/scripts/python/ftrimify.py
@@ -12,7 +12,7 @@ def ftrimify(parm):
     """
     if not isinstance(parm.parmTemplate(), hou.StringParmTemplate):
         return
-    pattern = r"((?<!ftrim\()chs*\(.*?\))"
+    pattern = r"((?<!ftrim\()(chs*\(.*?\)|@[^`]*))"
     repl = r"ftrim(\1)"
     raw = parm.rawValue()
     # Don't do anything if no match found


### PR DESCRIPTION
Even though the @ attributes don't seem to always suffer the same rounding error in string parms, they do when you start doing stuff like

````
`@someval + 0.02`
````